### PR TITLE
Fix telson to work with blit under ruby >1.8.7

### DIFF
--- a/lib/rbkb/plug/blit.rb
+++ b/lib/rbkb/plug/blit.rb
@@ -55,7 +55,7 @@ module Plug
       @buf.rewind
 
       return unless @buf.read(SIG.size) == SIG and
-                    op = OPCODES[ @buf.read(1)[0] ]
+                    op = OPCODES[ @buf.read(1)[0].ord ]
 
       initbuf if self.send(op)
     end


### PR DESCRIPTION
Ruby 1.8.x apparently treated raw bytes in StringIO as integers (sic!), whereas newer rubies properly show them as bytes in strings. This is why blit messages opcodes didn't map to OPCODES hash keys ("\x05" != 5).
