### PR TITLE
Fixing randomize for use with ruby 2+

### DIFF
--- a/lib/rbkb/extends/string.rb
+++ b/lib/rbkb/extends/string.rb
@@ -241,7 +241,7 @@ module Rbkb
 
       # String randomizer
       def randomize
-        self.split('').randomize.to_s
+        self.split('').randomize.join
       end
 
 


### PR DESCRIPTION
I'm not sure if you're interested in updating rbkb to work with ruby 2, but if you are, this change is useful.